### PR TITLE
fix: User Setting 成功編輯帳號資料卻跳出錯誤提示

### DIFF
--- a/src/components/AccountForm.vue
+++ b/src/components/AccountForm.vue
@@ -212,7 +212,6 @@ export default {
       this.account = newValue.account;
       this.name = newValue.name;
       this.email = newValue.email;
-      this.password = newValue.password;
     },
   },
 
@@ -290,13 +289,11 @@ export default {
             throw new Error(data.message);
           }
 
-          this.$router.push({
-            name: "UserInfo",
-            params: { account: this.account },
-          });
+          this.toggleNotice({type: "success", message: "成功編輯帳號資料"})
+          this.password = "";
+          this.checkPassword = "";
         }
       } catch (error) {
-        console.log("error");
         this.toggleNotice({ type: "error", message: error.message });
       }
     },


### PR DESCRIPTION
本來成功編輯後會redirect到UserInfo，但因為UserInfo之前改了params( account > id )，所以redirect失敗
目前更改成成功編輯後跳出成功編輯通知，但不redirect到其他頁面。
(因為目前通知是寫在單個component裡面，redirect之後就讀不到通知了)